### PR TITLE
Use upstream dependency from jitpack

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,7 +59,7 @@
 
         <source-file src="src/android/GridleriMatch.java" target-dir="src/com/gridler/iMatch" />
 
-        <framework src="com.clj.fastble:FastBleLib:2.3.2" />
+        <framework src="com.github.Jasonchenlijian:FastBle:2.3.2" />
 
     </platform>
 </plugin>


### PR DESCRIPTION
The original dependency is no longer freely available.